### PR TITLE
If the whole text is selected, clicking on a whitespace in the selected region exits selection mode

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/editor/text/Cursor.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/text/Cursor.java
@@ -32,7 +32,7 @@ public final class Cursor {
     private boolean mAutoIndentEnabled;
     private EditorLanguage mLanguage;
     private int mTabWidth;
-
+	
     /**
      * Create a new Cursor for Content
      *

--- a/editor/src/main/java/io/github/rosemoe/editor/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/widget/CodeEditor.java
@@ -513,11 +513,6 @@ public class CodeEditor extends View implements ContentListener, TextAnalyzer.Ca
      * Use {@link SymbolPairMatch.Replacement#NO_REPLACEMENT} to force no completion for a character
      */
     public SymbolPairMatch getOverrideSymbolPairs() {
-		mOverrideSymbolPairs.putPair('{', new SymbolPairMatch. Replacement("{}", 1));
-		mOverrideSymbolPairs.putPair('(', new SymbolPairMatch.Replacement("()", 1));
-		mOverrideSymbolPairs.putPair('[', new SymbolPairMatch.Replacement("[]", 1));
-		mOverrideSymbolPairs.putPair('"', new SymbolPairMatch.Replacement("\"\"", 1));
-		mOverrideSymbolPairs.putPair('\'', new SymbolPairMatch.Replacement("''", 1));
         return mOverrideSymbolPairs;
     }
 

--- a/editor/src/main/java/io/github/rosemoe/editor/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/widget/CodeEditor.java
@@ -513,6 +513,11 @@ public class CodeEditor extends View implements ContentListener, TextAnalyzer.Ca
      * Use {@link SymbolPairMatch.Replacement#NO_REPLACEMENT} to force no completion for a character
      */
     public SymbolPairMatch getOverrideSymbolPairs() {
+		mOverrideSymbolPairs.putPair('{', new SymbolPairMatch. Replacement("{}", 1));
+		mOverrideSymbolPairs.putPair('(', new SymbolPairMatch.Replacement("()", 1));
+		mOverrideSymbolPairs.putPair('[', new SymbolPairMatch.Replacement("[]", 1));
+		mOverrideSymbolPairs.putPair('"', new SymbolPairMatch.Replacement("\"\"", 1));
+		mOverrideSymbolPairs.putPair('\'', new SymbolPairMatch.Replacement("''", 1));
         return mOverrideSymbolPairs;
     }
 

--- a/editor/src/main/java/io/github/rosemoe/editor/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/widget/EditorTouchEventHandler.java
@@ -75,6 +75,9 @@ final class EditorTouchEventHandler implements GestureDetector.OnGestureListener
     }
 	
 	/**
+     * Checks whether the provided character is a whitespace
+     * 
+     * @param c the char to check
 	 * @return Whether the provided character is a whitespace
 	 */
 	private boolean isWhitespace(char c) {
@@ -82,7 +85,11 @@ final class EditorTouchEventHandler implements GestureDetector.OnGestureListener
     }
 	
 	/**
-	 * Handles the selected text click event
+     * Handles the selected text click event
+     * 
+     * @param e the MotionEvent
+     * @param line line number index
+     * @param column column index in line
 	 */ 
 	private void handleSelectedTextClick(MotionEvent e, int line, int column) {
 		if(mEditor.getTextActionPresenter() instanceof EditorTextActionWindow) {

--- a/editor/src/main/java/io/github/rosemoe/editor/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/widget/EditorTouchEventHandler.java
@@ -73,6 +73,27 @@ final class EditorTouchEventHandler implements GestureDetector.OnGestureListener
     private static boolean isIdentifierPart(char ch) {
         return Character.isJavaIdentifierPart(ch);
     }
+	
+	/**
+	 * @retuern Whether the provided character is a whitespace
+	 */
+	private boolean isWhitespace(char c) {
+        return (c == '\t' || c == ' ' || c == '\f' || c == '\n' || c == '\r');
+    }
+	
+	/**
+	 * Handles the selected text click event
+	 */ 
+	private void handleSelectedTextClick(MotionEvent e, int line, int column) {
+		if(mEditor.getTextActionPresenter() instanceof EditorTextActionWindow) {
+			char text = mEditor.getText().charAt(line, column);
+			if(isWhitespace(text) || ((EditorTextActionWindow) mEditor.getTextActionPresenter()).isShowing())
+				mEditor.setSelection(line, column);
+			else mEditor.getTextActionPresenter().onSelectedTextClicked(e);
+		} else {
+			mEditor.getTextActionPresenter().onSelectedTextClicked(e);
+		}
+	}
 
     /**
      * Whether we should draw scroll bars
@@ -349,7 +370,7 @@ final class EditorTouchEventHandler implements GestureDetector.OnGestureListener
         int line = IntPair.getFirst(res);
         int column = IntPair.getSecond(res);
         if (mEditor.getCursor().isSelected() && mEditor.getCursor().isInSelectedRegion(line, column) && !mEditor.isOverMaxY(e.getY())) {
-            mEditor.getTextActionPresenter().onSelectedTextClicked(e);
+            handleSelectedTextClick(e, line, column);	
         } else {
             notifyLater();
             mEditor.setSelection(line, column);

--- a/editor/src/main/java/io/github/rosemoe/editor/widget/EditorTouchEventHandler.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/widget/EditorTouchEventHandler.java
@@ -75,7 +75,7 @@ final class EditorTouchEventHandler implements GestureDetector.OnGestureListener
     }
 	
 	/**
-	 * @retuern Whether the provided character is a whitespace
+	 * @return Whether the provided character is a whitespace
 	 */
 	private boolean isWhitespace(char c) {
         return (c == '\t' || c == ' ' || c == '\f' || c == '\n' || c == '\r');

--- a/editor/src/main/java/io/github/rosemoe/editor/widget/SymbolPairMatch.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/widget/SymbolPairMatch.java
@@ -100,6 +100,8 @@ public class SymbolPairMatch {
             super.putPair('{', new Replacement("{}", 1));
             super.putPair('(', new Replacement("()", 1));
             super.putPair('[', new Replacement("[]", 1));
+            super.putPair('"', new Replacement("\"\"", 1));
+            super.putPair('\'', new Replacement("''", 1));
         }
 
     }

--- a/language-java/src/main/java/io/github/rosemoe/editor/langs/java/JavaLanguage.java
+++ b/language-java/src/main/java/io/github/rosemoe/editor/langs/java/JavaLanguage.java
@@ -22,6 +22,7 @@ import io.github.rosemoe.editor.interfaces.CodeAnalyzer;
 import io.github.rosemoe.editor.interfaces.EditorLanguage;
 import io.github.rosemoe.editor.langs.IdentifierAutoComplete;
 import io.github.rosemoe.editor.text.TextUtils;
+import io.github.rosemoe.editor.widget.SymbolPairMatch;
 
 /**
  * Java language is much complex.
@@ -70,6 +71,12 @@ public class JavaLanguage implements EditorLanguage {
     @Override
     public boolean useTab() {
         return true;
+    }
+	
+	@Override
+    public SymbolPairMatch getSymbolPairs()
+    {
+        return new SymbolPairMatch.DefaultSymbolPairs();
     }
 
     @Override


### PR DESCRIPTION
If the whole text is selected, clicking on a whitespace in the selected region exits selection mode.

* It's related to #46 (as mentioned in [this](https://github.com/Rosemoe/CodeEditor/issues/46#issuecomment-815457838)  comment.)

* JavaLanguage now returns ```DefaultSymbolPairs``` in ```JavaLanguage#getSymbolPairs()``` (#48)
* Added some common symbol pairs in ```CodeEditor#getOverrideSymbolPairs()``` (#44)