### PR TITLE
Fix ClassClassException in EditorAutoCompleteWindow

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/editor/widget/EditorAutoCompleteWindow.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/widget/EditorAutoCompleteWindow.java
@@ -195,7 +195,7 @@ public class EditorAutoCompleteWindow extends EditorBasePopupWindow {
      * @param pos Index of auto complete item
      */
     public void select(int pos) {
-        CompletionItem item = ((DefaultCompletionItemAdapter) mListView.getAdapter()).getItem(pos);
+        CompletionItem item = ((EditorCompletionAdapter) mListView.getAdapter()).getItem(pos);
         Cursor cursor = mEditor.getCursor();
         if (!cursor.isSelected()) {
             mCancelShowUp = true;


### PR DESCRIPTION
Fix ClassCastException in EditorAutoCompleteWindow when selecting an item from the completion list. This happens only when an adapter other than the ```DefaultCompletionListAdapter``` is set.