### PR TITLE
Fix syntax error  caused by last modification

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/editor/text/FontCache.java
+++ b/editor/src/main/java/io/github/rosemoe/editor/text/FontCache.java
@@ -39,7 +39,7 @@ public class FontCache {
     }
 
     private static boolean isEmoji(char ch) {
-        return ch == 0xd83c || ch == 0xd83d || 0xd83e;
+        return ch == 0xd83c || ch == 0xd83d || ch == 0xd83e;
     }
 
     /**


### PR DESCRIPTION
Fix syntax error in isEmoji method caused by last modification(修复上次修改引起的isEmoji方法中的语法错误)非常抱歉_(:з」∠)_