### PR TITLE
Added auto-close HTML tags in HTMLAutoComplete

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+	implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation project(path: ':editor')
     implementation project(path: ':language-java')
 	implementation project(path: ':language-html')

--- a/app/src/main/java/io/github/rosemoe/editor/app/MainActivity.java
+++ b/app/src/main/java/io/github/rosemoe/editor/app/MainActivity.java
@@ -15,7 +15,6 @@
  */
 package io.github.rosemoe.editor.app;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.graphics.Typeface;
 import android.os.Bundle;
@@ -27,6 +26,8 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -55,7 +56,7 @@ import io.github.rosemoe.editor.widget.schemes.SchemeGitHub;
 import io.github.rosemoe.editor.widget.schemes.SchemeNotepadXX;
 import io.github.rosemoe.editor.widget.schemes.SchemeVS2019;
 
-public class MainActivity extends Activity {
+public class MainActivity extends AppCompatActivity {
 
     private CodeEditor editor;
     private LinearLayout panel;
@@ -66,7 +67,7 @@ public class MainActivity extends Activity {
         super.onCreate(savedInstanceState);
         CrashHandler.INSTANCE.init(this);
         setContentView(R.layout.activity_main);
-
+		
         editor = findViewById(R.id.editor);
         panel = findViewById(R.id.search_panel);
         search = findViewById(R.id.search_editor);

--- a/language-html/src/main/java/io/github/rosemoe/editor/langs/html/HTMLAutoComplete.java
+++ b/language-html/src/main/java/io/github/rosemoe/editor/langs/html/HTMLAutoComplete.java
@@ -18,13 +18,28 @@ public class HTMLAutoComplete implements AutoCompleteProvider {
     @Override
     public List<CompletionItem> getAutoCompleteItems(String prefix, boolean isInCodeBlock, TextAnalyzeResult colors, int line) {
         List<CompletionItem> items = new ArrayList<>();
-        for (String key : HTMLLanguage.TAGS)
-            if (key.toLowerCase().startsWith(prefix.toLowerCase()))
-                items.add(new CompletionItem(key, "HTML Tag"));
+        for (String tag : HTMLLanguage.TAGS)
+            if (tag.toLowerCase().startsWith(prefix.toLowerCase()))
+                items.add(tagAsCompletion(tag, "HTML Tag"));
 
-        for (String key : HTMLLanguage.TAGS)
-            if (key.toLowerCase().startsWith(prefix.toLowerCase()))
-                items.add(new CompletionItem(key, "HTML Attribute"));
+        for (String attr : HTMLLanguage.ATTRIBUTES)
+            if (attr.toLowerCase().startsWith(prefix.toLowerCase()))
+                items.add(attrAsCompletion(attr, "HTML Attribute"));
         return items;
     }
+
+	private CompletionItem attrAsCompletion(String attr, String desc) {
+		final CompletionItem item = new CompletionItem(attr, attr.concat("=\"\""), desc);
+		item.cursorOffset(item.commit.length() - 1);
+		return item;
+	}
+
+	private CompletionItem tagAsCompletion(String tag, String desc) {
+		final String open = "<".concat(tag).concat(">");
+		final String close = "</".concat(tag).concat(">");
+		final CompletionItem item = new CompletionItem(tag, desc);
+		item.commit = open.concat(close);
+		item.cursorOffset(item.commit.length() - close.length());
+		return item;
+	}
 }

--- a/language-html/src/main/java/io/github/rosemoe/editor/langs/html/HTMLLanguage.java
+++ b/language-html/src/main/java/io/github/rosemoe/editor/langs/html/HTMLLanguage.java
@@ -31,7 +31,10 @@ public class HTMLLanguage implements EditorLanguage {
      */
     @Override
     public boolean isAutoCompleteChar(char ch) {
-        return Character.isLetter(ch);
+		// isDigit -> required to complete tags which may contain a number
+		// For example -> h1, h2, h3, h4...
+		// Better solution?
+        return Character.isLetter(ch) || Character.isDigit(ch);
     }
 
     @Override


### PR DESCRIPTION
- Fixed: HTML tags were being added again to the completion list instead of HTML attributes.
- Added: Append closing tag along with the opening tag.