### PR TITLE
Add setTextActionPresenter() to set custom EditorTextActionPresenters

### DIFF
--- a/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
+++ b/editor/src/main/java/io/github/rosemoe/sora/widget/CodeEditor.java
@@ -331,7 +331,7 @@ public class CodeEditor extends View implements ContentListener, TextAnalyzer.Ca
      * @return EditorTextActionPresenter
      */
     @NonNull
-    protected EditorTextActionPresenter getTextActionPresenter() {
+    public EditorTextActionPresenter getTextActionPresenter() {
         return mTextActionPresenter;
     }
 
@@ -784,6 +784,13 @@ public class CodeEditor extends View implements ContentListener, TextAnalyzer.Ca
         } else {
             mTextActionPresenter = new EditorTextActionWindow(this);
         }
+    }
+
+    /**
+     * Set an EditorTextActionPresenter for this editor
+     */
+    public void setTextActionPresenter(@NonNull EditorTextActionPresenter presenter) {
+        mTextActionPresenter = presenter;
     }
 
     /**


### PR DESCRIPTION
I found this to be useful when I wanted to customize the TextActionPopupWindow to edit **More** button, but it can be used to create custom popup windows as well.

Also made getTextActionPresenter() public for completeness.